### PR TITLE
修复一个小问题

### DIFF
--- a/CAPI/CAPI/CAPI/src/API.cpp
+++ b/CAPI/CAPI/CAPI/src/API.cpp
@@ -17,7 +17,7 @@ double TimeSinceStart(const std::chrono::system_clock::time_point &sp)
 template <bool asyn>
 API<asyn>::API(std::function<void(Protobuf::MessageToServer &)> sm,
 			   std::function<bool()> e, std::function<bool(std::string &)> tp,
-			   const State *&pS, std::mutex &mtx_game) : LogicInterface(sm, e, tp, pS), mtx(mtx_game)
+			   const State *&pS, std::mutex &mtx_game, std::function<void()> tu) : LogicInterface(sm, e, tp, pS), mtx_state(mtx_game), TryUpDate(tu)
 {
 }
 
@@ -108,11 +108,12 @@ std::vector<const THUAI4::Character *> API<asyn>::GetCharacterPtrs() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	std::vector<const THUAI4::Character *> characters;
 
-	for (const auto & it : pState->characters)
+	for (const auto &it : pState->characters)
 	{
 		characters.push_back(it.get());
 	}
@@ -123,7 +124,8 @@ std::vector<const THUAI4::Wall *> API<asyn>::GetWallPtrs() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	std::vector<const THUAI4::Wall *> walls;
 	for (const auto &it : pState->walls)
@@ -137,7 +139,8 @@ std::vector<const THUAI4::Prop *> API<asyn>::GetPropPtrs() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	std::vector<const THUAI4::Prop *> props;
 
@@ -152,7 +155,8 @@ std::vector<const THUAI4::Bullet *> API<asyn>::GetBulletPtrs() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	std::vector<const THUAI4::Bullet *> bullets;
 
@@ -167,7 +171,8 @@ std::vector<const THUAI4::BirthPoint *> API<asyn>::GetBirthPointPtrs() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	std::vector<const THUAI4::BirthPoint *> birthpoints;
 	for (const auto &it : pState->birthpoints)
@@ -181,7 +186,8 @@ const THUAI4::Character &API<asyn>::GetSelfInfoRef() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	return *pState->self;
 }
@@ -191,11 +197,12 @@ std::vector<THUAI4::Character> API<asyn>::GetCharacters() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	std::vector<THUAI4::Character> characters;
 
-	for (const auto& it : pState->characters)
+	for (const auto &it : pState->characters)
 	{
 		characters.push_back(*it.get());
 	}
@@ -206,7 +213,8 @@ std::vector<THUAI4::Wall> API<asyn>::GetWalls() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	std::vector<THUAI4::Wall> walls;
 
@@ -221,7 +229,8 @@ std::vector<THUAI4::Prop> API<asyn>::GetProps() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	std::vector<THUAI4::Prop> props;
 
@@ -236,7 +245,8 @@ std::vector<THUAI4::Bullet> API<asyn>::GetBullets() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	std::vector<THUAI4::Bullet> bullets;
 
@@ -251,7 +261,8 @@ std::vector<THUAI4::BirthPoint> API<asyn>::GetBirthPoints() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	std::vector<THUAI4::BirthPoint> birthpoints;
 
@@ -266,7 +277,8 @@ THUAI4::Character API<asyn>::GetSelfInfo() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	return *pState->self;
 }
@@ -276,7 +288,8 @@ THUAI4::ColorType API<asyn>::GetSelfTeamColor() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	return pState->selfTeamColor;
 }
@@ -285,7 +298,8 @@ uint32_t API<asyn>::GetTeamScore() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	return pState->teamScore;
 }
@@ -294,7 +308,8 @@ const std::array<std::array<int64_t, StateConstant::nPlayers>, StateConstant::nT
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	return pState->playerGUIDs;
 }
@@ -303,7 +318,8 @@ THUAI4::ColorType API<asyn>::GetCellColor(int CellX, int CellY) const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	assert(CellX >= 0 && CellX < StateConstant::nCells && CellY >= 0 && CellY < StateConstant::nCells);
 #ifdef _COLOR_MAP_BY_HASHING_
@@ -326,8 +342,9 @@ template class API<false>;
 template <bool asyn>
 DebugApi<asyn>::DebugApi(std::function<void(Protobuf::MessageToServer &)> sm,
 						 std::function<bool()> e, std::function<bool(std::string &)> tp,
-						 const State *&pS, std::mutex &mtx_game, bool ev,
-						 std::ostream &out) : LogicInterface(sm, e, tp, pS), ExamineValidity(ev), OutStream(out), mtx(mtx_game)
+						 const State *&pS, std::mutex &mtx_game, std::function<void()> tu, bool ev,
+						 std::ostream &out) : LogicInterface(sm, e, tp, pS), ExamineValidity(ev),
+											  OutStream(out), mtx_state(mtx_game), TryUpDate(tu)
 {
 }
 
@@ -543,7 +560,8 @@ std::vector<const THUAI4::Character *> DebugApi<asyn>::GetCharacterPtrs() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	OutStream << "Call GetCharacterPtrs() at " << TimeSinceStart(StartPoint) << "ms" << std::endl;
 	std::vector<const THUAI4::Character *> characters;
@@ -559,7 +577,8 @@ std::vector<const THUAI4::Wall *> DebugApi<asyn>::GetWallPtrs() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	OutStream << "Call GetWallPtrs() at " << TimeSinceStart(StartPoint) << "ms" << std::endl;
 
@@ -575,7 +594,8 @@ std::vector<const THUAI4::Prop *> DebugApi<asyn>::GetPropPtrs() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	OutStream << "Call GetPropPtrs() at " << TimeSinceStart(StartPoint) << "ms" << std::endl;
 
@@ -591,7 +611,8 @@ std::vector<const THUAI4::Bullet *> DebugApi<asyn>::GetBulletPtrs() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	OutStream << "Call GetBulletPtrs() at " << TimeSinceStart(StartPoint) << "ms" << std::endl;
 	std::vector<const THUAI4::Bullet *> bullets;
@@ -606,7 +627,8 @@ std::vector<const THUAI4::BirthPoint *> DebugApi<asyn>::GetBirthPointPtrs() cons
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	OutStream << "Call GetBirthPointPtrs() at " << TimeSinceStart(StartPoint) << "ms" << std::endl;
 	std::vector<const THUAI4::BirthPoint *> birthpoints;
@@ -621,7 +643,8 @@ const THUAI4::Character &DebugApi<asyn>::GetSelfInfoRef() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	OutStream << "Call GetSelfInfoRef() at " << TimeSinceStart(StartPoint) << "ms" << std::endl;
 	return *pState->self;
@@ -632,7 +655,8 @@ std::vector<THUAI4::Character> DebugApi<asyn>::GetCharacters() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	OutStream << "Call GetCharacters() at " << TimeSinceStart(StartPoint) << "ms" << std::endl;
 	std::vector<THUAI4::Character> characters;
@@ -648,7 +672,8 @@ std::vector<THUAI4::Wall> DebugApi<asyn>::GetWalls() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	OutStream << "Call GetWalls() at " << TimeSinceStart(StartPoint) << "ms" << std::endl;
 	std::vector<THUAI4::Wall> walls;
@@ -664,7 +689,8 @@ std::vector<THUAI4::Prop> DebugApi<asyn>::GetProps() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	OutStream << "Call GetProps() at " << TimeSinceStart(StartPoint) << "ms" << std::endl;
 	std::vector<THUAI4::Prop> props;
@@ -680,7 +706,8 @@ std::vector<THUAI4::Bullet> DebugApi<asyn>::GetBullets() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	OutStream << "Call GetBullets() at " << TimeSinceStart(StartPoint) << "ms" << std::endl;
 	std::vector<THUAI4::Bullet> bullets;
@@ -696,7 +723,8 @@ std::vector<THUAI4::BirthPoint> DebugApi<asyn>::GetBirthPoints() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	OutStream << "Call GetBirthPoints() at " << TimeSinceStart(StartPoint) << "ms" << std::endl;
 	std::vector<THUAI4::BirthPoint> birthpoints;
@@ -712,19 +740,20 @@ THUAI4::Character DebugApi<asyn>::GetSelfInfo() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	OutStream << "Call GetSelfInfo() at " << TimeSinceStart(StartPoint) << "ms" << std::endl;
 	return *pState->self;
 }
-
 
 template <bool asyn>
 THUAI4::ColorType DebugApi<asyn>::GetSelfTeamColor() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	OutStream << "Call GetSelfTeamColor() at " << TimeSinceStart(StartPoint) << "ms" << std::endl;
 	return pState->selfTeamColor;
@@ -734,7 +763,8 @@ uint32_t DebugApi<asyn>::GetTeamScore() const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	OutStream << "Call GetTeamScore() at " << TimeSinceStart(StartPoint) << "ms" << std::endl;
 	return pState->teamScore;
@@ -744,7 +774,8 @@ const std::array<std::array<int64_t, StateConstant::nPlayers>, StateConstant::nT
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	OutStream << "Call GetPlayerGUIDs() at " << TimeSinceStart(StartPoint) << "ms" << std::endl;
 	return pState->playerGUIDs;
@@ -754,7 +785,8 @@ THUAI4::ColorType DebugApi<asyn>::GetCellColor(int CellX, int CellY) const
 {
 	if constexpr (asyn)
 	{
-		std::lock_guard<std::mutex> lck(mtx);
+		std::lock_guard<std::mutex> lck(mtx_state);
+		TryUpDate();
 	}
 	OutStream << "Call GetCellColor(" << CellX << "," << CellY << ") at " << TimeSinceStart(StartPoint) << "ms" << std::endl;
 	assert(CellX >= 0 && CellX < StateConstant::nCells && CellY >= 0 && CellY < StateConstant::nCells);

--- a/CAPI/CAPI/CAPI/src/API.h
+++ b/CAPI/CAPI/CAPI/src/API.h
@@ -59,12 +59,13 @@ class API final : public LogicInterface
 private:
 	virtual void StartTimer() {}
 	virtual void EndTimer() {}
-	std::mutex &mtx; //并不总是需要，但……忍了吧
+	std::mutex &mtx_state; //并不总是需要，但……忍了吧
+	std::function<void()> TryUpDate;
 
 public:
 	API(std::function<void(Protobuf::MessageToServer &)> sm,
 		std::function<bool()> e, std::function<bool(std::string &)> tp,
-		const State *&pS, std::mutex &mtx_game);
+		const State *&pS, std::mutex &mtx_game, std::function<void()>);
 	virtual void MovePlayer(uint32_t timeInMilliseconds, double angle);
 	virtual void MoveRight(uint32_t timeInMilliseconds);
 	virtual void MoveUp(uint32_t timeInMilliseconds);
@@ -122,12 +123,13 @@ private:
 		{THUAI4::PropType::Totem, "Totem"}};
 	virtual void StartTimer();
 	virtual void EndTimer();
-	std::mutex &mtx;
+	std::mutex &mtx_state;
+	std::function<void()> TryUpDate;
 
 public:
 	DebugApi(std::function<void(Protobuf::MessageToServer &)> sm,
 			 std::function<bool()> e, std::function<bool(std::string &)> tp,
-			 const State *&pS, std::mutex &mtx_game, bool ev = false,
+			 const State *&pS, std::mutex &mtx_game, std::function<void()>, bool ev = false,
 			 std::ostream &out = std::cout);
 	virtual void MovePlayer(uint32_t timeInMilliseconds, double angle);
 	virtual void MoveRight(uint32_t timeInMilliseconds);

--- a/CAPI/CAPI/CAPI/src/Logic.cpp
+++ b/CAPI/CAPI/CAPI/src/Logic.cpp
@@ -426,7 +426,16 @@ void Logic::Main(const char *address, uint16_t port, int32_t playerID, int32_t t
 			this->pApi = std::make_shared<API<true>>([this](Protobuf::MessageToServer &M2C) {M2C.set_playerid(this->playerID); M2C.set_teamid(this->teamID); capi.Send(M2C); },
 													 [this]() { return MessageStorage.empty(); },
 													 [this](std::string &s) { return MessageStorage.try_pop(s); },
-													 (const State *&)pState, mtx_state);
+													 (const State *&)pState, mtx_state, [this]() {
+														 if(mtx_buffer.try_lock()){
+															 if(BufferUpdated){
+																 State* temp=pState;
+																 pState=pBuffer;
+																 pBuffer=temp;
+																 BufferUpdated=false;
+															 }
+															 mtx_buffer.unlock();
+														 } });
 		}
 		else
 		{
@@ -435,7 +444,16 @@ void Logic::Main(const char *address, uint16_t port, int32_t playerID, int32_t t
 				this->pApi = std::make_shared<DebugApi<true>>([this](Protobuf::MessageToServer &M2C) {M2C.set_playerid(this->playerID); M2C.set_teamid(this->teamID); capi.Send(M2C); },
 															  [this]() { return MessageStorage.empty(); },
 															  [this](std::string &s) { return MessageStorage.try_pop(s); },
-															  (const State *&)pState, mtx_state, debuglevel != 1);
+															  (const State *&)pState, mtx_state, [this]() {
+														 if(mtx_buffer.try_lock()){
+															 if(BufferUpdated){
+																 State* temp=pState;
+																 pState=pBuffer;
+																 pBuffer=temp;
+																 BufferUpdated=false;
+															 }
+															 mtx_buffer.unlock();
+														 } }, debuglevel != 1);
 			}
 			else
 			{
@@ -448,7 +466,16 @@ void Logic::Main(const char *address, uint16_t port, int32_t playerID, int32_t t
 				this->pApi = std::make_shared<DebugApi<true>>([this](Protobuf::MessageToServer &M2C) {M2C.set_playerid(this->playerID); M2C.set_teamid(this->teamID); capi.Send(M2C); },
 															  [this]() { return MessageStorage.empty(); },
 															  [this](std::string &s) { return MessageStorage.try_pop(s); },
-															  (const State *&)pState, mtx_state, debuglevel != 1, OutFile);
+															  (const State *&)pState, mtx_state, [this]() {
+														 if(mtx_buffer.try_lock()){
+															 if(BufferUpdated){
+																 State* temp=pState;
+																 pState=pBuffer;
+																 pBuffer=temp;
+																 BufferUpdated=false;
+															 }
+															 mtx_buffer.unlock();
+														 } }, debuglevel != 1, OutFile);
 			}
 		}
 	}
@@ -459,7 +486,16 @@ void Logic::Main(const char *address, uint16_t port, int32_t playerID, int32_t t
 			this->pApi = std::make_shared<API<false>>([this](Protobuf::MessageToServer &M2C) {M2C.set_playerid(this->playerID); M2C.set_teamid(this->teamID); capi.Send(M2C); },
 													  [this]() { return MessageStorage.empty(); },
 													  [this](std::string &s) { return MessageStorage.try_pop(s); },
-													  (const State *&)pState, mtx_state);
+													  (const State *&)pState, mtx_state, [this]() {
+														 if(mtx_buffer.try_lock()){
+															 if(BufferUpdated){
+																 State* temp=pState;
+																 pState=pBuffer;
+																 pBuffer=temp;
+																 BufferUpdated=false;
+															 }
+															 mtx_buffer.unlock();
+														 } });
 		}
 		else
 		{
@@ -468,7 +504,16 @@ void Logic::Main(const char *address, uint16_t port, int32_t playerID, int32_t t
 				this->pApi = std::make_shared<DebugApi<false>>([this](Protobuf::MessageToServer &M2C) {M2C.set_playerid(this->playerID); M2C.set_teamid(this->teamID); capi.Send(M2C); },
 															   [this]() { return MessageStorage.empty(); },
 															   [this](std::string &s) { return MessageStorage.try_pop(s); },
-															   (const State *&)pState, mtx_state, debuglevel != 1);
+															   (const State *&)pState, mtx_state, [this]() {
+														 if(mtx_buffer.try_lock()){
+															 if(BufferUpdated){
+																 State* temp=pState;
+																 pState=pBuffer;
+																 pBuffer=temp;
+																 BufferUpdated=false;
+															 }
+															 mtx_buffer.unlock();
+														 } }, debuglevel != 1);
 			}
 			else
 			{
@@ -481,7 +526,16 @@ void Logic::Main(const char *address, uint16_t port, int32_t playerID, int32_t t
 				this->pApi = std::make_shared<DebugApi<false>>([this](Protobuf::MessageToServer &M2C) {M2C.set_playerid(this->playerID); M2C.set_teamid(this->teamID); capi.Send(M2C); },
 															   [this]() { return MessageStorage.empty(); },
 															   [this](std::string &s) { return MessageStorage.try_pop(s); },
-															   (const State *&)pState, mtx_state, debuglevel != 1, OutFile);
+															   (const State *&)pState, mtx_state, [this]() {
+														 if(mtx_buffer.try_lock()){
+															 if(BufferUpdated){
+																 State* temp=pState;
+																 pState=pBuffer;
+																 pBuffer=temp;
+																 BufferUpdated=false;
+															 }
+															 mtx_buffer.unlock();
+														 } }, debuglevel != 1, OutFile);
 			}
 		}
 	}
@@ -544,7 +598,7 @@ void Logic::Main(const char *address, uint16_t port, int32_t playerID, int32_t t
 		}
 
 		std::cout << "游戏开始" << std::endl;
-		std::thread tAI(asynchronous?&Logic::PlayerWrapperAsyn:&Logic::PlayerWrapper, this);
+		std::thread tAI(asynchronous ? &Logic::PlayerWrapperAsyn : &Logic::PlayerWrapper, this);
 
 		while (gamePhase != GamePhase::GameOver && !UnexpectedlyClosed)
 			cv_game.wait(lck);


### PR DESCRIPTION
之前asyn情况下只有load那里会更新state，但可能mtx_state.try_lock时恰好API被调用，于是调用结束后buffer更新了state却要等到下次buffer更新才会更新。改后API调用锁住state后还会查看buffer是否可更新
（未测试过，睡了睡了）