### PR TITLE
rm previous ai before compiling again

### DIFF
--- a/CAPI/compile.sh
+++ b/CAPI/compile.sh
@@ -1,4 +1,5 @@
 cd CAPI/CAPI
+rm -f /usr/local/mnt/player/PLAYER*
 make SOURCE_DIR=/usr/local/mnt/cpp BIN_DIR=/usr/local/mnt/player/ &>  /usr/local/mnt/player/out.log
 cd /usr/local/mnt/player
 if [ [ -f ./PLAYER1 ] && [ -f ./PLAYER2 ] && [ -f ./PLAYER3 ] && [ -f ./PLAYER4 ] ]


### PR DESCRIPTION
之前通过判断路径下是否有 PLAYER1-4 来判断是否编译成功，并更新数据库的状态，但有一个问题是如果第一次编译成功，第二次编译失败，那么路径下第一次生成的 PLAYER1-4 还存在着，这时 Hasura 里的编译状态就是错的，因此在编译前把之前的可执行文件都删了