### PR TITLE
Linux上CAPI游戏结束杀死player线程 Agent在所有选手均退出后自动终止

### DIFF
--- a/CAPI/CAPI/CAPI/src/API.h
+++ b/CAPI/CAPI/CAPI/src/API.h
@@ -40,17 +40,17 @@ struct State
 struct LogicInterface : public GameApi
 {
 protected:
-	const std::function<bool(Protobuf::MessageToServer&)> SendMessageWrapper; //加入ID放到这个函数里了
+	const std::function<bool(Protobuf::MessageToServer &)> SendMessageWrapper; //加入ID放到这个函数里了
 	const std::function<bool()> Empty;
-	const std::function<bool(std::string&)> TryPop;
+	const std::function<bool(std::string &)> TryPop;
 	const std::function<int()> GetCounter;
 	const std::function<void()> _Wait;
-	const State*& pState;
+	const State *&pState;
 
 public:
-	LogicInterface(std::function<bool(Protobuf::MessageToServer&)> sm,
-		std::function<bool()> e, std::function<bool(std::string&)> tp, std::function<int()> gc,
-		const State*& pS, std::function<void()> w) : SendMessageWrapper(sm), Empty(e), TryPop(tp), GetCounter(gc), pState(pS), _Wait(w) {}
+	LogicInterface(std::function<bool(Protobuf::MessageToServer &)> sm,
+				   std::function<bool()> e, std::function<bool(std::string &)> tp, std::function<int()> gc,
+				   const State *&pS, std::function<void()> w) : SendMessageWrapper(sm), Empty(e), TryPop(tp), GetCounter(gc), _Wait(w), pState(pS) {}
 	virtual void StartTimer() = 0;
 	virtual void EndTimer() = 0;
 };
@@ -59,17 +59,17 @@ template <bool>
 struct Members
 {
 public:
-	Members(std::mutex& mtx_state, std::function<void()> f) {}
+	Members(std::mutex &mtx_state, std::function<void()> f) {}
 };
 
 template <>
 struct Members<true>
 {
 public:
-	Members(std::mutex& mtx_state, std::function<void()> f) : mtx_state(mtx_state), TryUpDate(f) {}
+	Members(std::mutex &mtx_state, std::function<void()> f) : mtx_state(mtx_state), TryUpDate(f) {}
 
 protected:
-	std::mutex& mtx_state;
+	std::mutex &mtx_state;
 	const std::function<void()> TryUpDate;
 };
 
@@ -81,9 +81,9 @@ private:
 	virtual void EndTimer() {}
 
 public:
-	API(std::function<bool(Protobuf::MessageToServer&)> sm,
-		std::function<bool()> e, std::function<bool(std::string&)> tp, std::function<int()> gc,
-		const State*& pS, std::mutex& mtx_state, std::function<void()> tu, std::function<void()> w);
+	API(std::function<bool(Protobuf::MessageToServer &)> sm,
+		std::function<bool()> e, std::function<bool(std::string &)> tp, std::function<int()> gc,
+		const State *&pS, std::mutex &mtx_state, std::function<void()> tu, std::function<void()> w);
 	virtual bool MovePlayer(uint32_t timeInMilliseconds, double angle);
 	virtual bool MoveRight(uint32_t timeInMilliseconds);
 	virtual bool MoveUp(uint32_t timeInMilliseconds);
@@ -100,7 +100,7 @@ public:
 	//Information the player can get
 	virtual int GetCounterOfFrames();
 	virtual bool MessageAvailable();
-	virtual bool TryGetMessage(std::string&);
+	virtual bool TryGetMessage(std::string &);
 
 	virtual std::vector<std::shared_ptr<const THUAI4::Character>> GetCharacters() const;
 	virtual std::vector<std::shared_ptr<const THUAI4::Wall>> GetWalls() const;
@@ -115,7 +115,6 @@ public:
 	virtual THUAI4::ColorType GetCellColor(int CellX, int CellY) const;
 };
 
-
 template class API<true>;
 template class API<false>;
 
@@ -124,7 +123,7 @@ class DebugApi final : public LogicInterface, Members<asyn>
 {
 private:
 	bool ExamineValidity;
-	std::ostream& OutStream;
+	std::ostream &OutStream;
 	std::chrono::system_clock::time_point StartPoint;
 	bool CanPick(THUAI4::PropType propType);
 	std::map<THUAI4::PropType, std::string> dict{
@@ -138,15 +137,15 @@ private:
 		{THUAI4::PropType::Null, "Null"},
 		{THUAI4::PropType::Phaser, "Phaser"},
 		{THUAI4::PropType::Rice, "Rice"},
-		{THUAI4::PropType::Totem, "Totem"} };
+		{THUAI4::PropType::Totem, "Totem"}};
 	virtual void StartTimer();
 	virtual void EndTimer();
 
 public:
-	DebugApi(std::function<bool(Protobuf::MessageToServer&)> sm,
-		std::function<bool()> e, std::function<bool(std::string&)> tp, std::function<int()> gc,
-		const State*& pS, std::mutex& mtx_state, std::function<void()> tu, std::function<void()> w, bool ev = false,
-		std::ostream& out = std::cout);
+	DebugApi(std::function<bool(Protobuf::MessageToServer &)> sm,
+			 std::function<bool()> e, std::function<bool(std::string &)> tp, std::function<int()> gc,
+			 const State *&pS, std::mutex &mtx_state, std::function<void()> tu, std::function<void()> w, bool ev = false,
+			 std::ostream &out = std::cout);
 	virtual bool MovePlayer(uint32_t timeInMilliseconds, double angle);
 	virtual bool MoveRight(uint32_t timeInMilliseconds);
 	virtual bool MoveUp(uint32_t timeInMilliseconds);
@@ -163,7 +162,7 @@ public:
 	//Information the player can get
 	virtual int GetCounterOfFrames();
 	virtual bool MessageAvailable();
-	virtual bool TryGetMessage(std::string&);
+	virtual bool TryGetMessage(std::string &);
 
 	virtual std::vector<std::shared_ptr<const THUAI4::Character>> GetCharacters() const;
 	virtual std::vector<std::shared_ptr<const THUAI4::Wall>> GetWalls() const;
@@ -194,6 +193,5 @@ inline bool CellColorVisible(int32_t x, int32_t y, int32_t CellX, int32_t CellY)
 	int32_t dy = (std::max)(std::abs(centerY - y) - half, 0);
 	return Constants::Map::sightRadiusSquared >= distance_squared(dx, dy);
 }
-
 
 #endif // !API_H

--- a/CAPI/CAPI/CAPI/src/CAPI.cpp
+++ b/CAPI/CAPI/CAPI/src/CAPI.cpp
@@ -136,6 +136,8 @@ bool  Communication<Message2S, typeM2S, Message2C1, typeM2C1, Message2C2, typeM2
 	if (!capi.Connect(address, port))
 	{
 		std::cout << "无法连接到Agent" << std::endl;
+		loop = false;
+		UnBlock();
 		tPM.join();
 		return false;
 	}
@@ -145,7 +147,7 @@ bool  Communication<Message2S, typeM2S, Message2C1, typeM2C1, Message2C2, typeM2
 template<typename Message2S, int typeM2S, typename Message2C1, int typeM2C1, typename Message2C2, int typeM2C2>
 bool  Communication<Message2S, typeM2S, Message2C1, typeM2C1, Message2C2, typeM2C2>::Send(const Message2S& m)
 {
-	if (counter == Limit) return false;
+	if (counter >= Limit) return false;
 	capi.Send(m);
 	counter++;
 	return true;

--- a/CAPI/CAPI/CAPI/src/Logic.cpp
+++ b/CAPI/CAPI/CAPI/src/Logic.cpp
@@ -5,7 +5,7 @@
 extern const bool asynchronous;
 
 //辅助函数
-std::shared_ptr<THUAI4::Character> obj2C(const Protobuf::GameObjInfo& goi)
+std::shared_ptr<THUAI4::Character> obj2C(const Protobuf::GameObjInfo &goi)
 {
 	std::shared_ptr<THUAI4::Character> character = std::make_shared<THUAI4::Character>();
 	character->ap = goi.ap();
@@ -30,7 +30,7 @@ std::shared_ptr<THUAI4::Character> obj2C(const Protobuf::GameObjInfo& goi)
 	character->y = goi.y();
 	return character;
 }
-std::shared_ptr<THUAI4::Wall> obj2W(const Protobuf::GameObjInfo& goi)
+std::shared_ptr<THUAI4::Wall> obj2W(const Protobuf::GameObjInfo &goi)
 {
 	std::shared_ptr<THUAI4::Wall> wall = std::make_shared<THUAI4::Wall>();
 	wall->guid = goi.guid();
@@ -40,7 +40,7 @@ std::shared_ptr<THUAI4::Wall> obj2W(const Protobuf::GameObjInfo& goi)
 	wall->y = goi.y();
 	return wall;
 }
-std::shared_ptr<THUAI4::Prop> obj2P(const Protobuf::GameObjInfo& goi)
+std::shared_ptr<THUAI4::Prop> obj2P(const Protobuf::GameObjInfo &goi)
 {
 	std::shared_ptr<THUAI4::Prop> prop = std::make_shared<THUAI4::Prop>();
 	prop->facingDirection = goi.facingdirection();
@@ -55,7 +55,7 @@ std::shared_ptr<THUAI4::Prop> obj2P(const Protobuf::GameObjInfo& goi)
 	prop->y = goi.y();
 	return prop;
 }
-std::shared_ptr<THUAI4::Bullet> obj2Blt(const Protobuf::GameObjInfo& goi)
+std::shared_ptr<THUAI4::Bullet> obj2Blt(const Protobuf::GameObjInfo &goi)
 {
 	std::shared_ptr<THUAI4::Bullet> bullet = std::make_shared<THUAI4::Bullet>();
 	bullet->ap = goi.ap();
@@ -71,7 +71,7 @@ std::shared_ptr<THUAI4::Bullet> obj2Blt(const Protobuf::GameObjInfo& goi)
 	bullet->y = goi.y();
 	return bullet;
 }
-std::shared_ptr<THUAI4::BirthPoint> obj2Bp(const Protobuf::GameObjInfo& goi)
+std::shared_ptr<THUAI4::BirthPoint> obj2Bp(const Protobuf::GameObjInfo &goi)
 {
 	std::shared_ptr<THUAI4::BirthPoint> birthpoint = std::make_shared<THUAI4::BirthPoint>();
 	birthpoint->guid = goi.guid();
@@ -82,7 +82,7 @@ std::shared_ptr<THUAI4::BirthPoint> obj2Bp(const Protobuf::GameObjInfo& goi)
 	birthpoint->y = goi.y();
 	return birthpoint;
 }
-bool visible(int32_t x, int32_t y, Protobuf::GameObjInfo& g)
+bool visible(int32_t x, int32_t y, Protobuf::GameObjInfo &g)
 {
 	Protobuf::GameObjType gT = g.gameobjtype();
 	Protobuf::PropType pT = g.proptype();
@@ -107,7 +107,8 @@ void Logic::ProcessM2C(std::shared_ptr<Protobuf::MessageToClient> pM2C)
 
 		//playerGuid只在这里记录
 		State::playerGUIDs.clear();
-		for (auto i : pM2C->playerguids()) {
+		for (auto i : pM2C->playerguids())
+		{
 			State::playerGUIDs.push_back(std::vector<int64_t>(i.teammateguids().cbegin(), i.teammateguids().cend()));
 		}
 		sw_AI = true;
@@ -121,14 +122,21 @@ void Logic::ProcessM2C(std::shared_ptr<Protobuf::MessageToClient> pM2C)
 
 	case Protobuf::MessageType::EndGame:
 	{
+
+//服务器上跑直接就把 player 线程杀死，防止某些选手的代码是死循环不能正常退出
+#ifdef __linux__
+		pthread_cancel(tAI.native_handle());
+#else
 		sw_AI = false;
-		std::cout << "游戏结束" << std::endl;
 		{
 			std::lock_guard<std::mutex> lck(mtx_buffer);
 			FlagBufferUpdated = true;
 			counter_buffer = -1;
 		}
 		cv_buffer.notify_one();
+
+#endif
+		std::cout << "游戏结束" << std::endl;
 		break;
 	}
 
@@ -184,7 +192,7 @@ void Logic::load(std::shared_ptr<Protobuf::MessageToClient> pM2C)
 #else
 				visible(selfX, selfY, it)
 #endif // _ALL_VISIBLE_
-				)
+			)
 			{
 				switch (it.gameobjtype())
 				{
@@ -219,7 +227,7 @@ void Logic::load(std::shared_ptr<Protobuf::MessageToClient> pM2C)
 #else
 					CellColorVisible(selfX, selfY, i, j)
 #endif
-					)
+				)
 				{
 #ifdef _COLOR_MAP_BY_HASHING_
 					pBuffer->cellColors.insert(std::pair((i << 16) + j, (THUAI4::ColorType)pM2C->cellcolors(i).rowcolors(j)));
@@ -285,7 +293,7 @@ void Logic::UnBlockAI()
 
 void Logic::Update()
 {
-	State* temp = pState;
+	State *temp = pState;
 	pState = pBuffer;
 	pBuffer = temp;
 	FlagBufferUpdated = false;
@@ -295,9 +303,14 @@ void Logic::Update()
 
 void Logic::PlayerWrapper(std::function<void()> player)
 {
+#ifdef __linux__
+	//收到后立刻执行，可能会 crash
+	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+#endif
 	{
 		std::unique_lock<std::mutex> lock(mtx_ai);
-		cv_ai.wait(lock, [this]() {return WhetherToStartKnown; });
+		cv_ai.wait(lock, [this]()
+				   { return WhetherToStartKnown; });
 	}
 	while (sw_AI)
 	{
@@ -305,8 +318,7 @@ void Logic::PlayerWrapper(std::function<void()> player)
 	}
 }
 
-
-void Logic::Main(const char* address, uint16_t port, int32_t playerID, int32_t teamID, THUAI4::JobType jobType, CreateAIFunc f, int debuglevel, std::string filename)
+void Logic::Main(const char *address, uint16_t port, int32_t playerID, int32_t teamID, THUAI4::JobType jobType, CreateAIFunc f, int debuglevel, std::string filename)
 {
 	//初始化
 
@@ -328,12 +340,11 @@ void Logic::Main(const char* address, uint16_t port, int32_t playerID, int32_t t
 			message.set_jobtype((Protobuf::JobType)jobType);
 			pComm->Send(message);
 		},
-			[this]()
+		[this]()
 		{
 			sw_AI = false;
 			UnBlockMtxBufferUpdated();
-		}
-		);
+		});
 
 	std::ofstream OutFile;
 	{
@@ -342,24 +353,35 @@ void Logic::Main(const char* address, uint16_t port, int32_t playerID, int32_t t
 		{
 			if (mtx_buffer.try_lock())
 			{
-				if (FlagBufferUpdated) Update();
+				if (FlagBufferUpdated)
+					Update();
 				mtx_buffer.unlock();
 			}
 		};
 		std::function<void()> wait = [this]()
 		{
 			std::unique_lock<std::mutex> lck_buffer(mtx_buffer);
-			cv_buffer.wait(lck_buffer, [this]() { return FlagBufferUpdated; });
+			cv_buffer.wait(lck_buffer, [this]()
+						   { return FlagBufferUpdated; });
 			Update();
 		};
 		if (asynchronous)
 		{
 			if (!debuglevel)
 			{
-				pApi = std::make_unique<API<true>>([this, playerID, teamID](Protobuf::MessageToServer& M2C) {M2C.set_playerid(playerID); M2C.set_teamid(teamID); return pComm->Send(M2C); },
-					[this]() { return MessageStorage.empty(); },
-					[this](std::string& s) { return MessageStorage.try_pop(s); }, [this]() { return counter_state; },
-					(const State*&)pState, mtx_state, tu, wait);
+				pApi = std::make_unique<API<true>>([this, playerID, teamID](Protobuf::MessageToServer &M2C)
+												   {
+													   M2C.set_playerid(playerID);
+													   M2C.set_teamid(teamID);
+													   return pComm->Send(M2C);
+												   },
+												   [this]()
+												   { return MessageStorage.empty(); },
+												   [this](std::string &s)
+												   { return MessageStorage.try_pop(s); },
+												   [this]()
+												   { return counter_state; },
+												   (const State *&)pState, mtx_state, tu, wait);
 			}
 			else
 			{
@@ -373,21 +395,38 @@ void Logic::Main(const char* address, uint16_t port, int32_t playerID, int32_t t
 						flag = true;
 					}
 				}
-				pApi = std::make_unique<DebugApi<true>>([this, playerID, teamID](Protobuf::MessageToServer& M2C) {M2C.set_playerid(playerID); M2C.set_teamid(teamID); return pComm->Send(M2C); },
-					[this]() { return MessageStorage.empty(); },
-					[this](std::string& s) { return MessageStorage.try_pop(s); }, [this]() { return counter_state; },
-					(const State*&)pState, mtx_state, tu, wait, debuglevel != 1,
-					flag ? std::cout : OutFile);
+				pApi = std::make_unique<DebugApi<true>>([this, playerID, teamID](Protobuf::MessageToServer &M2C)
+														{
+															M2C.set_playerid(playerID);
+															M2C.set_teamid(teamID);
+															return pComm->Send(M2C);
+														},
+														[this]()
+														{ return MessageStorage.empty(); },
+														[this](std::string &s)
+														{ return MessageStorage.try_pop(s); },
+														[this]()
+														{ return counter_state; },
+														(const State *&)pState, mtx_state, tu, wait, debuglevel != 1, flag ? std::cout : OutFile);
 			}
 		}
 		else
 		{
 			if (!debuglevel)
 			{
-				pApi = std::make_unique<API<false>>([this, playerID, teamID](Protobuf::MessageToServer& M2C) {M2C.set_playerid(playerID); M2C.set_teamid(teamID); return pComm->Send(M2C); },
-					[this]() { return MessageStorage.empty(); },
-					[this](std::string& s) { return MessageStorage.try_pop(s); }, [this]() { return counter_state; },
-					(const State*&)pState, mtx_state, tu, wait);
+				pApi = std::make_unique<API<false>>([this, playerID, teamID](Protobuf::MessageToServer &M2C)
+													{
+														M2C.set_playerid(playerID);
+														M2C.set_teamid(teamID);
+														return pComm->Send(M2C);
+													},
+													[this]()
+													{ return MessageStorage.empty(); },
+													[this](std::string &s)
+													{ return MessageStorage.try_pop(s); },
+													[this]()
+													{ return counter_state; },
+													(const State *&)pState, mtx_state, tu, wait);
 			}
 			else
 			{
@@ -401,48 +440,56 @@ void Logic::Main(const char* address, uint16_t port, int32_t playerID, int32_t t
 						flag = true;
 					}
 				}
-				pApi = std::make_unique<DebugApi<false>>([this, playerID, teamID](Protobuf::MessageToServer& M2C) {M2C.set_playerid(playerID); M2C.set_teamid(teamID); return pComm->Send(M2C); },
-					[this]() { return MessageStorage.empty(); },
-					[this](std::string& s) { return MessageStorage.try_pop(s); }, [this]() { return counter_state; },
-					(const State*&)pState, mtx_state, tu, wait, debuglevel != 1,
-					flag ? std::cout : OutFile);
+				pApi = std::make_unique<DebugApi<false>>([this, playerID, teamID](Protobuf::MessageToServer &M2C)
+														 {
+															 M2C.set_playerid(playerID);
+															 M2C.set_teamid(teamID);
+															 return pComm->Send(M2C);
+														 },
+														 [this]()
+														 { return MessageStorage.empty(); },
+														 [this](std::string &s)
+														 { return MessageStorage.try_pop(s); },
+														 [this]()
+														 { return counter_state; },
+														 (const State *&)pState, mtx_state, tu, wait, debuglevel != 1, flag ? std::cout : OutFile);
 			}
 		}
-
 	}
 
 	//启动AI线程（但要等到游戏开始才会正式执行）
-	std::thread tAI(&Logic::PlayerWrapper, this,
-		asynchronous ?
-		(std::function<void()>)[this]() {
-			//异步似乎反而逻辑变简洁了
-			pApi->StartTimer();
-			pAI->play(*pApi);
-			pApi->EndTimer();
-		}
-		:
-		(std::function<void()>)[this]() {
-			std::lock_guard<std::mutex> lck_state(mtx_state);
-			if (!CurrentStateAccessed)
-			{	
-				CurrentStateAccessed = true;
-				pApi->StartTimer();//再细一些的分类可以把这里去掉，但似乎没太大意义
+	tAI = std::thread(
+		&Logic::PlayerWrapper, this,
+		asynchronous ? (std::function<void()>)[this]()
+			{
+				//异步似乎反而逻辑变简洁了
+				pApi->StartTimer();
 				pAI->play(*pApi);
 				pApi->EndTimer();
-				
 			}
-			else
+					 : (std::function<void()>)[this]()
 			{
-				std::unique_lock<std::mutex> lck_buffer(mtx_buffer);
-				//如果buffer没更新就等
-				cv_buffer.wait(lck_buffer, [this]() { return FlagBufferUpdated; });
-				Update();
-			}
-		}
-		);
+				std::lock_guard<std::mutex> lck_state(mtx_state);
+				if (!CurrentStateAccessed)
+				{
+					CurrentStateAccessed = true;
+					pApi->StartTimer(); //再细一些的分类可以把这里去掉，但似乎没太大意义
+					pAI->play(*pApi);
+					pApi->EndTimer();
+				}
+				else
+				{
+					std::unique_lock<std::mutex> lck_buffer(mtx_buffer);
+					//如果buffer没更新就等
+					cv_buffer.wait(lck_buffer, [this]()
+								   { return FlagBufferUpdated; });
+					Update();
+				}
+			});
 
 	//试图连接Agent
-	if (!pComm->Start(address, port)) {
+	if (!pComm->Start(address, port))
+	{
 		sw_AI = false;
 		UnBlockAI();
 		tAI.join();
@@ -451,7 +498,8 @@ void Logic::Main(const char* address, uint16_t port, int32_t playerID, int32_t t
 	}
 	std::cout << "Connect to the agent successfully." << std::endl;
 
-	tAI.join();
+	if (tAI.joinable())
+		tAI.join();
 	OutFile.close();
 	pComm->Join();
 }

--- a/CAPI/CAPI/CAPI/src/Logic.h
+++ b/CAPI/CAPI/CAPI/src/Logic.h
@@ -35,6 +35,8 @@ private:
 	std::unique_ptr<LogicInterface> pApi;
 	std::unique_ptr<AIBase> pAI;
 
+	std::thread tAI;
+
 	volatile std::int32_t counter_state = 0;
 	volatile std::int32_t counter_buffer = 0;
 	State* pState;

--- a/CAPI/CAPI/CAPI/src/player.cpp
+++ b/CAPI/CAPI/CAPI/src/player.cpp
@@ -6,6 +6,7 @@ extern const bool asynchronous = true;
 
 #include <random>
 #include <iostream>
+#include <thread>
 
 /* 请于 VS2019 项目属性中开启 C++17 标准：/std:c++17 */
 
@@ -20,13 +21,8 @@ namespace
 
 void AI::play(GameApi& g)
 {
-	static int counter1 = 0;
-	static int counter2 = 0;
-	counter1 += g.MovePlayer(50, direction(e));
-	counter2 += 1;
-	if (g.GetCounterOfFrames() == 200) {
-		std::cout << counter1 << std::endl;
-		std::cout << counter2 << std::endl;
-		g.Wait();
+	while(true){
+		std::this_thread::sleep_for(std::chrono::seconds(1));
+		std::cout<<"I`m sleeping..."<<std::endl;
 	}
 }


### PR DESCRIPTION
CAPI 用 pthread_cancel。但设置的是PTHREAD_CANCEL_ASYNCHRONOUS 有可能会crash
Agent 改为当所有连接都断掉后自动退出